### PR TITLE
Java 21 as backend base line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+/.local
+# compiled output
+/dist
+/tmp
+/out-tsc
+/target
+
+# dependencies
+node_modules
+
+# IDEs and editors
+**/.run
+**/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+*.iml
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db
+
+### AWS SAM ###
+**/.aws*
+
+### Java Artifacts ###
+HELP.md
+**/target/
+!**/src/main/**/target/
+!**/src/test/**/target/
+!**/.mvn/wrapper/maven-wrapper.jar
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Oferecer uma visão clara e padronizada da arquitetura de software, visando apoi
 
 ### backend/java/
 
-- **Tecnologia:** Java 17+ com Spring Boot 3.x
+- **Tecnologia:** Java 21+ com Spring Boot 3.x
 - **Camadas:** Controller, Service, Repository, DTOs
 - **Recursos:** API REST com OpenAPI (Swagger), banco de dados relacional (PostgreSQL, MySQL), autenticação OAuth2
 - **Extras:** Testes com JUnit 5, perfil de ambientes, conteinerização com Docker


### PR DESCRIPTION
The New Java LTS (25) will be released in September, so it makes sense, IMHO, to use the current LTS version (21) as a baseline. The current AI model should already have Java21 information, and the backend can use important Java features like Virtual Threads.